### PR TITLE
Clear old results, fix wrong output

### DIFF
--- a/tui/torrent.go
+++ b/tui/torrent.go
@@ -34,7 +34,7 @@ func fetchTorrents(p string, q string, c string, s string, f string) string {
 	}
 
 	if len(res) == 0 {
-		return "No results found"
+		return "No results found\n"
 	}
 
 	initialLayout := "Mon, 02 Jan 2006 15:04:05 -0700"

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -165,6 +165,7 @@ func setupMainPage(p *tview.Pages, provider string, info *tview.TextView) *tview
 				torrents = fetchTorrents("sukebei", query, c, s, f)
 			}
 
+			table.Clear()
 			setTableData(table, torrents[:len(torrents)-1]) // remove last \n
 			app.SetFocus(table)
 			table.ScrollToBeginning()


### PR DESCRIPTION
Hello, this PR should solve a couple of issues:

1. When starting a search, previous results are not removed and can cause incorrect results.
2. If no torrents are found, the "No results found" text has the last character missing.