### PR TITLE
Fix panic by omitting torrents that do not contain a download link

### DIFF
--- a/tui/torrent.go
+++ b/tui/torrent.go
@@ -41,6 +41,10 @@ func fetchTorrents(p string, q string, c string, s string, f string) string {
 	dateLayout := "2006-01-02"
 
 	for _, v := range res {
+		if !strings.Contains(v.Link, "download/") {
+			continue
+		}
+
 		t, _ := time.Parse(initialLayout, v.Date)
 		date := t.Format(dateLayout)
 


### PR DESCRIPTION
Hello, this should fix a panic that closes the application when it encounters a torrent that does not have a download link.

**Steps to reproduce:**
- Search for "strawberry panic"
- The application closes

The panic occurs because the torrent `[AMF] Strawberry Panic! DVD 01-26 [Sub Esp]` only has a magnet link and the torrent id in `fetchTorrents` is being extracted from the download link.

**Solution:**
- Hide torrents that do not have a download link